### PR TITLE
Arregla KeyError en WeightingFunction cuando se usa __getitem__

### DIFF
--- a/src/algoritmia/datastructures/digraphs/weightingfunction.py
+++ b/src/algoritmia/datastructures/digraphs/weightingfunction.py
@@ -4,7 +4,7 @@ from collections import Callable
 
 class WeightingFunction(IMap, Callable): #[weighting
     def __init__(self, data: "Iterable<((T, T), K)> or IMap<(T, T), K>" =[], #?data?¶data?
-                       symmetrical: "bool"=False, 
+                       symmetrical: "bool"=False,
                        createMap: "Iterable<((T, T), K)> -> IMap<(T, T), K>"
                             =lambda keyvalues: dict(keyvalues)): #?symm?»symm?
         self.createMap = createMap
@@ -26,7 +26,7 @@ class WeightingFunction(IMap, Callable): #[weighting
     def __setitem__(self, key: "(T, T)", value: "K") -> "K":
         self._map[key] = value
         return value
-    
+
     def get(self, key: "(T, T)", default: "K") -> "K":
         return self._map.get(key, default)
 
@@ -43,16 +43,20 @@ class WeightingFunction(IMap, Callable): #[weighting
         return self._map.items()
 
     def __getitem__(self, key: "(T, T)") -> "K":
-        return self._map[key]
-    
+        u, v = key
+        if (u, v) in self._map:
+            return self._map[u, v]
+        elif self.symmetrical:
+            return self._map[v, u]
+        raise KeyError(repr((u, v)))
+
     def __iter__(self) -> "Iterable<(T, T)>":
         return iter(self._map)
-    
+
     def __len__(self) -> "int":
         return len(self._map)
-    
+
     def __call__(self, u: "T or (T, T)", v: "T or None"=None) -> "K":
-        if v == None: u, v = u
-        if (u,v) in self._map: return self._map[u,v]
-        elif self.symmetrical: return self._map[v,u]
-        raise KeyError(repr((u,v))) #]weighting
+        if v is None:
+            u, v = u
+        return self.__getitem__((u, v))

--- a/src/tests/datastructures/test_graphs.py
+++ b/src/tests/datastructures/test_graphs.py
@@ -205,9 +205,16 @@ class TestWeightingFunction(unittest.TestCase):
         self.assertEqual(self.sym(1,1), 2)
         self.assertEqual(self.sym(1,2), 3)
         self.assertEqual(self.sym(2,1), 3)
+        self.assertEqual(self.sym((2,1)), 3)
+        self.assertEqual(self.sym[2,1], 3)
+        self.assertEqual(self.sym[1,2], 3)
+        self.assertRaises(KeyError, self.sym.__getitem__, (1, 3))
+        self.assertRaises(KeyError, self.sym.__call__, (1,3))
         self.assertEqual(self.asym(0,0), 1)
         self.assertEqual(self.asym(1,1), 2)
         self.assertEqual(self.asym(1,2), 3)
+        self.assertEqual(self.asym[1,2], 3)
+        self.assertRaises(KeyError, self.asym.__getitem__, (2, 1))
         self.assertRaises(KeyError, self.asym.__call__, (2,1))
 
 if __name__ == "__main__":


### PR DESCRIPTION
Cuando se usa *\_\_getitem\_\_* en un objeto **WeightingFunction** con
*symmetrical=True* lanza **KeyError** aunque la clave exista.

Ejemplo:

```python
from algoritmia.datastructures.digraphs import  WeightingFunction


wf = WeightingFunction({('A', 'B'): 100}, symmetrical=True)
print(wf('A', 'B')) # OK -> 100
print(wf['A', 'B']) # OK -> 100
print(wf['B', 'A']) # KeyError
```