### PR TITLE
RuntimeError: dictionary changed size during iteration

### DIFF
--- a/src/algoritmia/datastructures/digraphs/weightingfunction.py
+++ b/src/algoritmia/datastructures/digraphs/weightingfunction.py
@@ -11,11 +11,16 @@ class WeightingFunction(IMap, Callable): #[weighting
         self._map = self.createMap(data)
         self.symmetrical = symmetrical
         if symmetrical:
+            duplicates = set()
             for (u, v) in self._map.keys():
                 if (v, u) in self._map:
                     if self._map[u, v] != self._map[v, u]:
                         raise ValueError("{!r} is different from {!r}".format((u,v), (v,u)))
-                    if v != u: del self._map[v, u]
+                    if v != u and (u, v) not in duplicates:
+                        duplicates.add((v, u))
+
+            for dup in duplicates:
+                self._map.pop(dup)
 
     def __contains__(self, key: "(T, T)") -> "bool":
         return key in self._map


### PR DESCRIPTION
Al crear un **WeightingFunction** que sea *symmetrical* con claves duplicadas, intenta borrar claves del mapa mientras itera sobre **keys()**:

```python
for (u, v) in self._map.keys():
    if (v, u) in self._map:
        # ...
        if v != u: del self._map[v, u]
```
Ejemplo:

```python
wf = WeightingFunction({('A', 'B'): 1, ('B', 'A'): 1, ('C', 'D'): 2}, symmetrical=True)
# RuntimeError: dictionary changed size during iteration
```