### PR TITLE
Ensuring Cross-Platform Compatibility

### DIFF
--- a/src/coverage_test.py
+++ b/src/coverage_test.py
@@ -25,7 +25,7 @@ cov.start()
 loaded = set()
 suite = unittest.TestSuite()
 for module in test_paths:
-    mod = importlib.import_module(''.join(module.split(".")[:-1]).replace("\\", "."))
+    mod = importlib.import_module(''.join(module.split(".")[:-1]).replace(os.sep, "."))
     exec("import {}".format(mod.__name__))
     for c in dir(mod):
         if c.startswith("Test"):


### PR DESCRIPTION
When working with file paths in a cross-platform manner, it's important to use the appropriate path separator. For example, Linux uses '/' while Windows uses '\\'. Instead of hardcoding these separators, you can use os.sep from the os module, which will handle the correct separator for the operating system you are using.